### PR TITLE
feat: allow overriding package in installDependencies

### DIFF
--- a/src/create-app-functions.js
+++ b/src/create-app-functions.js
@@ -98,17 +98,17 @@ export async function copyTemplate(appName, templateDir, targetWorkingDir, files
   });
 }
 
-export function installDependencies(targetWorkingDir, wizardPackageName, debug) {
+export function installDependencies(targetWorkingDir, packageName = '@soundworks/create', debug = false) {
   const execOptions = {
     cwd: targetWorkingDir,
     stdio: 'inherit',
   };
 
   // install itself as a dev dependency
-  execSync(`npm install --save-dev @soundworks/create --silent`, execOptions);
+  execSync(`npm install --save-dev ${packageName} --silent`, execOptions);
 
   if (debug) {
-    execSync(`npm link @soundworks/create`, execOptions);
+    execSync(`npm link ${packageName}`, execOptions);
   }
 }
 


### PR DESCRIPTION
Allow specifying the package to install in installDependencies.
This seems to have been the initial intention behind the previously unused `wizardPackageName` variable.